### PR TITLE
Use CSS :hover pseudo-class instead of manual emulation.

### DIFF
--- a/src/walk-path.css
+++ b/src/walk-path.css
@@ -5,6 +5,8 @@ path.walk-path {
 
   transition: stroke .2s, stroke-width .2s;
   transition-timing-function: ease-in;
+
+  pointer-events: none !important;
 }
 
 path.walk-path.highlighted {
@@ -19,7 +21,9 @@ path.walk-path.selected {
   stroke-width: 3.5px;
 }
 
-path.walk-path.hover {
+/* Also show hover effect when hovering over a hidden preceding sibling. */
+path.walk-path:hover,
+path.hidden:hover + path.walk-path {
   stroke-width: 4px;
   transition: stroke-width .2s;
   transition-timing-function: ease;
@@ -29,6 +33,7 @@ path.walk-path.hover {
 path.hidden {
   opacity: 0;
   stroke-width: 20px;
+  pointer-events: initial !important;
 }
 
 

--- a/src/walk-path.css
+++ b/src/walk-path.css
@@ -1,4 +1,4 @@
-path {
+path.walk-path {
   stroke: #1175FF;
   stroke-width: 2px;
   opacity: .8;
@@ -7,7 +7,7 @@ path {
   transition-timing-function: ease-in;
 }
 
-path.highlighted {
+path.walk-path.highlighted {
   stroke: #FF9F00;
   stroke-width: 2px;
 
@@ -15,11 +15,11 @@ path.highlighted {
   transition-timing-function: ease-out;
 }
 
-path.selected {
+path.walk-path.selected {
   stroke-width: 3.5px;
 }
 
-path.hover {
+path.walk-path.hover {
   stroke-width: 4px;
   transition: stroke-width .2s;
   transition-timing-function: ease;

--- a/src/walk-path.js
+++ b/src/walk-path.js
@@ -4,23 +4,8 @@ import { DomEvent } from 'leaflet';
 import './walk-path.css';
 
 class WalkPath extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      hover: false
-    };
-  }
-  handleMouseOver() {
-    this.setState({ hover: true });
-  }
-  handleMouseOut() {
-    this.setState({ hover: false });
-  }
   render() {
     var className = 'walk-path';
-    if (this.state.hover) {
-      className += ' hover';
-    }
     if (this.props.selected) {
       className += ' selected';
     }
@@ -30,18 +15,16 @@ class WalkPath extends React.Component {
     return (
       <div>
         <Polyline
-          className={className}
-          positions={this.props.positions} />
-        <Polyline
           className='hidden'
           positions={this.props.positions}
-          onMouseOver={() => this.handleMouseOver()}
-          onMouseOut={() => this.handleMouseOut()}
           onClick={e => {
             this.props.onClick();
             DomEvent.stopPropagation(e);
           }}
         />
+        <Polyline
+          className={className}
+          positions={this.props.positions} />
       </div>
     );
   }

--- a/src/walk-path.js
+++ b/src/walk-path.js
@@ -17,7 +17,7 @@ class WalkPath extends React.Component {
     this.setState({ hover: false });
   }
   render() {
-    var className = '';
+    var className = 'walk-path';
     if (this.state.hover) {
       className += ' hover';
     }


### PR DESCRIPTION
This works by showing the hover effect also when hovering over a previous
hidden sibling by using an 'adjacent' selector in CSS.

Since 'adjacent' only allows styling the *successive* sibling, the hidden
path must be rendered *before* the visible path. Unfortunately, this
adversely affects mouse events which now need to be forwarded manually —
bubbling doesn't occur because the elements are siblings, not nested. You
win some, you lose some.

Caveat: completely untested.