### PR TITLE
Revert "Use PolyLine's 'interactive' property instead of CSS 'pointer-events'."

### DIFF
--- a/src/walk-path.css
+++ b/src/walk-path.css
@@ -5,6 +5,8 @@ path.walk-path {
 
   transition: stroke .2s, stroke-width .2s;
   transition-timing-function: ease-in;
+
+  pointer-events: none !important;
 }
 
 path.walk-path.highlighted {
@@ -31,6 +33,7 @@ path.hidden:hover + path.walk-path {
 path.hidden {
   opacity: 0;
   stroke-width: 20px;
+  pointer-events: initial !important;
 }
 
 

--- a/src/walk-path.js
+++ b/src/walk-path.js
@@ -24,7 +24,6 @@ class WalkPath extends React.Component {
         />
         <Polyline
           className={className}
-          interactive=false
           positions={this.props.positions} />
       </div>
     );


### PR DESCRIPTION
Reverts sgrj/berlin-walks#2

This doesn't seem to work for me. Clicking on the (visible) path directly doesn't trigger an event on the invisible path, so it cannot be used to select the walk.